### PR TITLE
Ignoring common files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,20 @@
 /log/*
 !/log/.keep
 /tmp
+*.swp
+
+# Ignore Vagrant
+.vagrant/*
+vagrant_ansible_inventory_default
+*.dump
+
+# env files
+/.env
+/.env.*
+!/.env.example
+vendor/bundle/*
+
+coverage/*
+.vimrc.local
+.zshrc.local
+.DS_Store


### PR DESCRIPTION
Noticed we were checking in .dstore files. Which aren't needed in the
repo.

Adding them to gitignore will stop git from adding them to the
repository :)